### PR TITLE
Accessibility changes

### DIFF
--- a/js/adapt-flipper.js
+++ b/js/adapt-flipper.js
@@ -5,7 +5,7 @@ define(function(require) {
 
     var Flipper = ComponentView.extend({
         events: {
-            "click .flipper-container": "onClick"
+            "click .flipper-container, .flipper-button": "onClick"
         },
 
         preRender: function() {
@@ -26,6 +26,7 @@ define(function(require) {
         onImageReady: function() {
             this.setItemVisibility();
             this.setItemHeights();
+            this.setScreenReaderVisibility();
             this.setReadyStatus();
         },
 
@@ -54,6 +55,10 @@ define(function(require) {
             }, this);
         },
 
+        setScreenReaderVisibility: function() {
+            this.$(".flipper-active-item").empty().prepend(this.$(".flipper-item.state-1").clone());
+        },
+
         onClick: function() {
             if (this.locked) return;
 
@@ -77,6 +82,9 @@ define(function(require) {
             setTimeout(function() {
                 $flipper.removeClass("animating");
                 this.locked = false;
+                this.setScreenReaderVisibility();
+                // Set aria live after first item is populated
+                this.$(".flipper-active-item").attr("aria-live", "polite");
             }.bind(this), 600);
         },
 

--- a/less/flipper.less
+++ b/less/flipper.less
@@ -11,6 +11,15 @@
 		-ms-perspective: 1000px;
 		width: 100%;
 		max-width: 100%;
+
+		.screen-reader-only {
+			position: absolute;
+			left: -10000px;
+			top: auto;
+			width: 1px;
+			height: 1px;
+			overflow: hidden;
+		}
 	}
 
 	.flipper {

--- a/templates/flipper.hbs
+++ b/templates/flipper.hbs
@@ -2,7 +2,7 @@
 	{{> component this}}
 	<div class="flipper-widget component-widget">
 		<div class="flipper-container">
-			<div class="flipper stage-0">
+			<div class="flipper stage-0" aria-hidden="true">
 				{{#each _items}}
 					<div class="flipper-item nth-child-{{@index}} state-0">
 						{{#if title}}<div class="flipper-item-title">{{{a11y_text title}}}</div>{{/if}}
@@ -11,9 +11,11 @@
 							{{#if _graphic.src}}<img class="flipper-item-img" src="{{_graphic.src}}" alt="{{_graphic.alt}}">{{/if}}
 						{{/if}}
 						{{#if instruction}}<div class="flipper-item-instruction">{{{a11y_text instruction}}}</div>{{/if}}
+						<button class="flipper-button screen-reader-only" aria-label="Flip to next item"></button>
 					</div>
 				{{/each}}
 			</div>
+			<div class="screen-reader-only flipper-active-item" aria-atomic="true"></div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Uses aria-live to make this component accessible.

Hide flipper cards to screen readers and push active card into aria-live region so that it can be read by a screenreader. Add 'Flip to next item' button which is visible to screen readers only to aid navigation.